### PR TITLE
guardians AI is not implemented. removing from maze-map

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -13,6 +13,8 @@ from map_utils import next_floor
 from menus import main_menu, message_box
 from render_functions import clear_all, render_all
 
+DEBUG = True
+
 def play_game(player, entities, game_map, message_log, game_state, root_console, con, panel, sidebar, constants):
     tdl.set_font('arial10x10.png', greyscale=True, altLayout=True)
 
@@ -71,6 +73,9 @@ def play_game(player, entities, game_map, message_log, game_state, root_console,
         show_character_screen = action.get('show_character_screen')
         exit = action.get('exit')
         fullscreen = action.get('fullscreen')
+
+        skip_floor = action.get('skip_floor')
+
 
         left_click = mouse_action.get('left_click')
         right_click = mouse_action.get('right_click')
@@ -147,6 +152,15 @@ def play_game(player, entities, game_map, message_log, game_state, root_console,
                     break
             else:
                 message_log.add_message(Message('There are no stairs here.', constants['colors'].get('yellow')))
+
+        if skip_floor and DEBUG == True:
+            ''' Pressing Shift+S will skip the current floor.
+            ATENTION: It is necessary for the player to make a first step
+            at each floor before skipping (it's a bug, not a feature!) ''' 
+            game_map, entities = next_floor(player, message_log, entity.stairs.floor, constants)
+            fov_recompute = True
+            con.clear()
+
 
         if level_up:
             if level_up == 'hp':
@@ -298,6 +312,7 @@ def play_game(player, entities, game_map, message_log, game_state, root_console,
 
             else:
                 game_state = GameStates.PLAYERS_TURN
+
 
 def main():
     constants = get_constants()

--- a/input_handlers.py
+++ b/input_handlers.py
@@ -60,6 +60,9 @@ def handle_player_turn_keys(user_input):
     elif key_char == 'c':
         return {'show_character_screen': True}
 
+    elif key_char == 's' and user_input.shift:
+        return {'skip_floor': True}
+
     if user_input.key == 'ENTER' and user_input.alt:
         # Alt+Enter: toggle full screen
         return {'fullscreen': True}

--- a/map_utils.py
+++ b/map_utils.py
@@ -91,7 +91,7 @@ def place_entities(room, entities, dungeon_level, colors, level_type, open_cells
             (x, y) = open_cells.pop()
             generate_monsters(x, y, entities, dungeon_level, colors)
 
-        (x, y) = open_cells.pop
+        (x, y) = open_cells.pop()
         generate_epic_monster(x, y, entities, colors)
 
         for i in range(max_items_per_maze):

--- a/map_utils.py
+++ b/map_utils.py
@@ -183,11 +183,11 @@ def make_maze_map(game_map, map_width, map_height, player, entities, colors, lev
                  stairs=Stairs(game_map.dungeon_level + 1))
     entities.append(down_stairs)
 
-    guardian = (Entity(x, y, 'M', colors.get('purple'), 'Guardian Minotaur', blocks=True,
-                       render_order=RenderOrder.ACTOR,
-                       fighter=Fighter(hp=80, defense=4, power=8, xp=1000),
-                       ai=GuardianMonster()))
-    entities.append(guardian)
+    # guardian = (Entity(x, y, 'M', colors.get('purple'), 'Guardian Minotaur', blocks=True,
+    #                    render_order=RenderOrder.ACTOR,
+    #                    fighter=Fighter(hp=80, defense=4, power=8, xp=1000),
+    #                    ai=GuardianMonster()))
+    # entities.append(guardian)
 
     room = Rect(0,0,0,0)
 


### PR DESCRIPTION
Guardians are pushed into maze map but their AI is not implemented, which causes the game to fail initializing the level. This patch removes the guardian spawn from the maze map.

In order to quickly test the changes I created a new DEBUG flag in engine.py and a new input handler (Shift+S). There's a bug where Shift+S will only work if the player takes at least one step at each level before skipping.